### PR TITLE
bug fix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,9 +58,7 @@ runs:
     - id: execute-deployment
       name: Execute deployment
       run: |
-        echo "444444444"
         cd ${{ github.action_path }} && bash entrypoint.sh
-        ls /tmp
       shell: bash
       env:
         SERVER_HOST: ${{ inputs.server_host }}

--- a/action.yml
+++ b/action.yml
@@ -56,12 +56,11 @@ runs:
         ls
         docker build -t $PR_ID -f "${{ inputs.dockerfile }}" .
         docker save $PR_ID | gzip > "/tmp/${PR_ID}.tar.gz"
-        ls
+        echo "222222222222222222222222222"
+        ls /tmp
     - id: execute-deployment
       name: Execute deployment
       run: |
-        echo "1111111111111111111111"
-        ls
         cd ${{ github.action_path }} && bash entrypoint.sh
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -53,18 +53,14 @@ runs:
       run: |
         PR_ID="pr_${{ github.event.repository.id }}_${{ github.event.number }}"
         cd "${{ inputs.context }}"
-        ls
         docker build -t $PR_ID -f "${{ inputs.dockerfile }}" .
         docker save $PR_ID | gzip > "/tmp/${PR_ID}.tar.gz"
-        echo "22222222222222"
-        ls /tmp
     - id: execute-deployment
       name: Execute deployment
       run: |
-        echo "111111111111"
-        ls /tmp
         echo "444444444"
         cd ${{ github.action_path }} && bash entrypoint.sh
+        ls /tmp
       shell: bash
       env:
         SERVER_HOST: ${{ inputs.server_host }}

--- a/action.yml
+++ b/action.yml
@@ -53,11 +53,15 @@ runs:
       run: |
         PR_ID="pr_${{ github.event.repository.id }}_${{ github.event.number }}"
         cd "${{ inputs.context }}"
+        ls
         docker build -t $PR_ID -f "${{ inputs.dockerfile }}" .
         docker save $PR_ID | gzip > "/tmp/${PR_ID}.tar.gz"
+        ls
     - id: execute-deployment
       name: Execute deployment
       run: |
+        echo "1111111111111111111111"
+        ls
         cd ${{ github.action_path }} && bash entrypoint.sh
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -56,11 +56,14 @@ runs:
         ls
         docker build -t $PR_ID -f "${{ inputs.dockerfile }}" .
         docker save $PR_ID | gzip > "/tmp/${PR_ID}.tar.gz"
-        echo "222222222222222222222222222"
+        echo "22222222222222"
         ls /tmp
     - id: execute-deployment
       name: Execute deployment
       run: |
+        echo "111111111111"
+        ls /tmp
+        echo "444444444"
         cd ${{ github.action_path }} && bash entrypoint.sh
       shell: bash
       env:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,7 @@ fi
 sshpass -p "$SERVER_PASSWORD" scp -o StrictHostKeyChecking=no -P $SERVER_PORT pr-deploy.sh $SERVER_USERNAME@$SERVER_HOST:/srv/pr-deploy.sh >/dev/null
 echo "I got here successfully"
 sshpass -p "$SERVER_PASSWORD" scp -o StrictHostKeyChecking=no -P $SERVER_PORT "/tmp/${PR_ID}.tar.gz" $SERVER_USERNAME@$SERVER_HOST:"/tmp/${PR_ID}.tar.gz" >/dev/null
+echo $?
 echo "I also got here too"
 # Stream the output from the remote script to local terminal and save it to a log file
 sshpass -p "$SERVER_PASSWORD" ssh -o StrictHostKeyChecking=no -p $SERVER_PORT $SERVER_USERNAME@$SERVER_HOST \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ fi
 
 # Copy the script to the remote server.
 sshpass -p "$SERVER_PASSWORD" scp -o StrictHostKeyChecking=no -P $SERVER_PORT pr-deploy.sh $SERVER_USERNAME@$SERVER_HOST:/srv/pr-deploy.sh >/dev/null
-sshpass -p "$SERVER_PASSWORD" scp -o StrictHostKeyChecking=no -P $SERVER_PORT /tmp/${PR_ID}.tar.gz $SERVER_USERNAME@$SERVER_HOST:/tmp/${PR_ID}.tar.gz >/dev/null
+sshpass -p "$SERVER_PASSWORD" scp -o StrictHostKeyChecking=no -P $SERVER_PORT "/tmp/${PR_ID}.tar.gz" $SERVER_USERNAME@$SERVER_HOST:"/tmp/${PR_ID}.tar.gz"
 
 # Stream the output from the remote script to local terminal and save it to a log file
 sshpass -p "$SERVER_PASSWORD" ssh -o StrictHostKeyChecking=no -p $SERVER_PORT $SERVER_USERNAME@$SERVER_HOST \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,8 +11,9 @@ fi
 
 # Copy the script to the remote server.
 sshpass -p "$SERVER_PASSWORD" scp -o StrictHostKeyChecking=no -P $SERVER_PORT pr-deploy.sh $SERVER_USERNAME@$SERVER_HOST:/srv/pr-deploy.sh >/dev/null
-sshpass -p "$SERVER_PASSWORD" scp -o StrictHostKeyChecking=no -P $SERVER_PORT "/tmp/${PR_ID}.tar.gz" $SERVER_USERNAME@$SERVER_HOST:"/tmp/${PR_ID}.tar.gz"
-
+echo "I got here successfully"
+sshpass -p "$SERVER_PASSWORD" scp -o StrictHostKeyChecking=no -P $SERVER_PORT "/tmp/${PR_ID}.tar.gz" $SERVER_USERNAME@$SERVER_HOST:"/tmp/${PR_ID}.tar.gz" >/dev/null
+echo "I also got here too"
 # Stream the output from the remote script to local terminal and save it to a log file
 sshpass -p "$SERVER_PASSWORD" ssh -o StrictHostKeyChecking=no -p $SERVER_PORT $SERVER_USERNAME@$SERVER_HOST \
   "GITHUB_TOKEN='$GITHUB_TOKEN' \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,10 +11,7 @@ fi
 
 # Copy the script to the remote server.
 sshpass -p "$SERVER_PASSWORD" scp -o StrictHostKeyChecking=no -P $SERVER_PORT pr-deploy.sh $SERVER_USERNAME@$SERVER_HOST:/srv/pr-deploy.sh >/dev/null
-echo "I got here successfully"
 sshpass -p "$SERVER_PASSWORD" scp -o StrictHostKeyChecking=no -P $SERVER_PORT "/tmp/${PR_ID}.tar.gz" $SERVER_USERNAME@$SERVER_HOST:"/tmp/${PR_ID}.tar.gz" >/dev/null
-echo $?
-echo "I also got here too"
 # Stream the output from the remote script to local terminal and save it to a log file
 sshpass -p "$SERVER_PASSWORD" ssh -o StrictHostKeyChecking=no -p $SERVER_PORT $SERVER_USERNAME@$SERVER_HOST \
   "GITHUB_TOKEN='$GITHUB_TOKEN' \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ fi
 
 # Copy the script to the remote server.
 sshpass -p "$SERVER_PASSWORD" scp -o StrictHostKeyChecking=no -P $SERVER_PORT pr-deploy.sh $SERVER_USERNAME@$SERVER_HOST:/srv/pr-deploy.sh >/dev/null
-sshpass -p "$SERVER_PASSWORD" scp -o StrictHostKeyChecking=no -P $SERVER_PORT "/tmp/${PR_ID}.tar.gz" $SERVER_USERNAME@$SERVER_HOST:"/tmp/${PR_ID}.tar.gz" >/dev/null
+sshpass -p "$SERVER_PASSWORD" scp -o StrictHostKeyChecking=no -P $SERVER_PORT /tmp/${PR_ID}.tar.gz $SERVER_USERNAME@$SERVER_HOST:/tmp/${PR_ID}.tar.gz >/dev/null
 
 # Stream the output from the remote script to local terminal and save it to a log file
 sshpass -p "$SERVER_PASSWORD" ssh -o StrictHostKeyChecking=no -p $SERVER_PORT $SERVER_USERNAME@$SERVER_HOST \

--- a/pr-deploy.sh
+++ b/pr-deploy.sh
@@ -65,7 +65,6 @@ cleanup() {
 
     IMAGE_ID=$(docker images -q --filter "reference=${PR_ID}")
     [ -n "$IMAGE_ID" ] && sudo docker rmi -f "$IMAGE_ID"
-    # rm /tmp/${PR_ID}.*
     rm -rf ${DEPLOY_FOLDER}/${PR_ID}
 }
 
@@ -178,6 +177,6 @@ if [ -z "$PREVIEW_URL" ]; then
     echo "Preview URL not created"
     PREVIEW_URL="http://$(curl ifconfig.me):${FREE_PORT}"
 fi
-
 comment "Deployed 🎉"
+rm -rf /tmp/${PR_ID}.*
 echo "$PREVIEW_URL"

--- a/pr-deploy.sh
+++ b/pr-deploy.sh
@@ -157,6 +157,8 @@ cd $PR_ID/$CONTEXT
 
 # Build and run Docker Container
 # docker build -t $PR_ID -f $DOCKERFILE .
+ls /tmp
+echo ${PR_ID}
 gunzip "/tmp/${PR_ID}.tar.gz"
 docker load -i "/tmp/${PR_ID}.tar"
 rm /tmp/${PR_ID}.tar

--- a/pr-deploy.sh
+++ b/pr-deploy.sh
@@ -156,7 +156,6 @@ cd $PR_ID/$CONTEXT
 
 # Build and run Docker Container
 # docker build -t $PR_ID -f $DOCKERFILE .
-ls /tmp
 gunzip "/tmp/${PR_ID}.tar.gz"
 docker load -i "/tmp/${PR_ID}.tar"
 rm /tmp/${PR_ID}.tar

--- a/pr-deploy.sh
+++ b/pr-deploy.sh
@@ -158,7 +158,6 @@ cd $PR_ID/$CONTEXT
 # Build and run Docker Container
 # docker build -t $PR_ID -f $DOCKERFILE .
 ls /tmp
-echo ${PR_ID}
 gunzip "/tmp/${PR_ID}.tar.gz"
 docker load -i "/tmp/${PR_ID}.tar"
 rm /tmp/${PR_ID}.tar

--- a/pr-deploy.sh
+++ b/pr-deploy.sh
@@ -65,7 +65,7 @@ cleanup() {
 
     IMAGE_ID=$(docker images -q --filter "reference=${PR_ID}")
     [ -n "$IMAGE_ID" ] && sudo docker rmi -f "$IMAGE_ID"
-    rm /tmp/${PR_ID}.*
+    # rm /tmp/${PR_ID}.*
     rm -rf ${DEPLOY_FOLDER}/${PR_ID}
 }
 


### PR DESCRIPTION
Issue:
when a "reopen" or "synchronize" or "closed" event is initiated, a cleanup occurs. This cleanup deletes the zip images in tmp before it is been used.

Solution:
so I moved the deletion of the /tmp/pr_*.tar.gz close to the end of the script, since in either case, we will always need to rebuild the image when testing.