### PR TITLE
Fix: Perform cleanup on deployment failure

### DIFF
--- a/pr-deploy.sh
+++ b/pr-deploy.sh
@@ -161,7 +161,7 @@ echo $ENVS > "/tmp/${PR_ID}.env"
 docker run -d --env-file "/tmp/${PR_ID}.env" -p $FREE_PORT:$EXPOSED_PORT --name $PR_ID $PR_ID
 
 # Start SSH Tunnel
-nohup ssh -tt -o StrictHostKeyChecking=no -R 80:localhost:$FREE_PORT serveo.net > serveo_output.log 2>&1 &
+nohupsi ssh -tt -o StrictHostKeyChecking=no -R 80:localhost:$FREE_PORT serveo.net > serveo_output.log 2>&1 &
 SERVEO_PID=$!
 sleep 3
 PREVIEW_URL=$(grep "Forwarding HTTP traffic from" serveo_output.log | tail -n 1 | awk '{print $5}')

--- a/pr-deploy.sh
+++ b/pr-deploy.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-# trap 'comment "Failed ❌" && exit 1' ERR
 trap 'cleanup; comment "Failed ❌"; exit 1' ERR
 
 DEPLOY_FOLDER="/srv/pr-deploy"
@@ -159,9 +158,6 @@ docker load -i "/tmp/${PR_ID}.tar"
 rm /tmp/${PR_ID}.tar
 echo $ENVS > "/tmp/${PR_ID}.env"
 docker run -d --env-file "/tmp/${PR_ID}.env" -p $FREE_PORT:$EXPOSED_PORT --name $PR_ID $PR_ID
-
-# Test if cleanup at deployment failure is working
-false
 
 # Start SSH Tunnel
 nohup ssh -tt -o StrictHostKeyChecking=no -R 80:localhost:$FREE_PORT serveo.net > serveo_output.log 2>&1 &

--- a/pr-deploy.sh
+++ b/pr-deploy.sh
@@ -164,13 +164,13 @@ docker run -d --env-file "/tmp/${PR_ID}.env" -p $FREE_PORT:$EXPOSED_PORT --name 
 nohupsi ssh -tt -o StrictHostKeyChecking=no -R 80:localhost:$FREE_PORT serveo.net > serveo_output.log 2>&1 &
 SERVEO_PID=$!
 sleep 3
-PREVIEW_URL=$(grep "Forwarding HTTP traffic from" serveo_output.log | tail -n 1 | awk '{print $5}')
+# PREVIEW_URL=$(grep "Forwarding HTTP traffic from" serveo_output.log | tail -n 1 | awk '{print $5}')
 echo "$PREVIEW_URLS" > "/tmp/${PR_ID}.txt"
 
 # update the nohup ids
 jq --arg pr_id "$PR_ID" --arg pid "$SERVEO_PID" '.[$pr_id] = $pid' "$PID_FILE" > "${PID_FILE}.tmp" && mv "${PID_FILE}.tmp" "$PID_FILE"
 
-if [ -z "$PREVIEW_URL" ]; then
+if [ -TT "$PREVIEW_URL" ]; then
     echo "Preview URL not created"
     PREVIEW_URL="http://$(curl ifconfig.me):${FREE_PORT}"
 fi

--- a/pr-deploy.sh
+++ b/pr-deploy.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 set -e
-trap 'comment "Failed ❌" && exit 1' ERR
+# trap 'comment "Failed ❌" && exit 1' ERR
+trap 'cleanup; comment "Failed ❌"; exit 1' ERR
 
 DEPLOY_FOLDER="/srv/pr-deploy"
 PID_FILE="/srv/pr-deploy/nohup.json"

--- a/pr-deploy.sh
+++ b/pr-deploy.sh
@@ -165,7 +165,7 @@ nohupsi ssh -tt -o StrictHostKeyChecking=no -R 80:localhost:$FREE_PORT serveo.ne
 SERVEO_PID=$!
 sleep 3
 PREVIEW_URL=$(grep "Forwarding HTTP traffic from" serveo_output.log | tail -n 1 | awk '{print $5}')
-echo "$PREVIEW_URL" > "/tmp/${PR_ID}.txt"
+echo "$PREVIEW_URLS" > "/tmp/${PR_ID}.txt"
 
 # update the nohup ids
 jq --arg pr_id "$PR_ID" --arg pid "$SERVEO_PID" '.[$pr_id] = $pid' "$PID_FILE" > "${PID_FILE}.tmp" && mv "${PID_FILE}.tmp" "$PID_FILE"

--- a/pr-deploy.sh
+++ b/pr-deploy.sh
@@ -160,6 +160,9 @@ rm /tmp/${PR_ID}.tar
 echo $ENVS > "/tmp/${PR_ID}.env"
 docker run -d --env-file "/tmp/${PR_ID}.env" -p $FREE_PORT:$EXPOSED_PORT --name $PR_ID $PR_ID
 
+# Test if cleanup at deployment failure is working
+false
+
 # Start SSH Tunnel
 nohup ssh -tt -o StrictHostKeyChecking=no -R 80:localhost:$FREE_PORT serveo.net > serveo_output.log 2>&1 &
 SERVEO_PID=$!

--- a/pr-deploy.sh
+++ b/pr-deploy.sh
@@ -161,19 +161,20 @@ echo $ENVS > "/tmp/${PR_ID}.env"
 docker run -d --env-file "/tmp/${PR_ID}.env" -p $FREE_PORT:$EXPOSED_PORT --name $PR_ID $PR_ID
 
 # Start SSH Tunnel
-nohupsi ssh -tt -o StrictHostKeyChecking=no -R 80:localhost:$FREE_PORT serveo.net > serveo_output.log 2>&1 &
+nohup ssh -tt -o StrictHostKeyChecking=no -R 80:localhost:$FREE_PORT serveo.net > serveo_output.log 2>&1 &
 SERVEO_PID=$!
 sleep 3
-# PREVIEW_URL=$(grep "Forwarding HTTP traffic from" serveo_output.log | tail -n 1 | awk '{print $5}')
-echo "$PREVIEW_URLS" > "/tmp/${PR_ID}.txt"
+PREVIEW_URL=$(grep "Forwarding HTTP traffic from" serveo_output.log | tail -n 1 | awk '{print $5}')
+echo "$PREVIEW_URL" > "/tmp/${PR_ID}.txt"
 
 # update the nohup ids
 jq --arg pr_id "$PR_ID" --arg pid "$SERVEO_PID" '.[$pr_id] = $pid' "$PID_FILE" > "${PID_FILE}.tmp" && mv "${PID_FILE}.tmp" "$PID_FILE"
 
-if [ -TT "$PREVIEW_URL" ]; then
+if [ -z "$PREVIEW_URL" ]; then
     echo "Preview URL not created"
     PREVIEW_URL="http://$(curl ifconfig.me):${FREE_PORT}"
 fi
+
 comment "Deployed 🎉"
 rm -rf /tmp/${PR_ID}.*
 echo "$PREVIEW_URL"


### PR DESCRIPTION
Included a call to the cleanup function in the trap statement. This ensures that the cleanup is performed when a deployment fails.

Link to test: https://github.com/Data-Bishop/flask-example/actions/runs/10263071450/job/28394071941